### PR TITLE
add kitchen docker config file

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,23 @@
+driver:
+  name: docker
+
+provisioner:
+  name: chef_zero
+
+# Uncomment the following verifier to leverage Inspec instead of Busser (the
+# default verifier)
+# verifier:
+#   name: inspec
+#   format: doc
+
+platforms:
+  - name: centos-6.5
+    driver_config:
+      forward:
+      - 27017:27017 
+
+suites:
+  - name: default
+    run_list:
+      - recipe[koala-mongodb::default]
+    attributes:


### PR DESCRIPTION
This adds a .kitchen.docker.yml file to config kitchen.

It uses centos 6.5 and exposes the default mongo port of 27017.
